### PR TITLE
Fix for routing uuid link

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1360,6 +1360,18 @@
             return match(path, options);
         };
     })();
+
+    (function() {
+        var goto = simply.route.goto;
+        simply.route.goto = function(path) {
+            let uuidPath = '/curriculum/uuid/';
+            if (path.substr(0, uuidPath.length)===uuidPath) {
+                history.pushState({}, '', path);
+                return simply.route.match(path);
+            }
+            return goto(path);
+        };
+    })();
     
     var titles = {
         'vakleergebied/': 'Vakleergebied',


### PR DESCRIPTION
Instead of adding curriculum/2022/api/v1/uuid/ to the uuid link, instead the link will turn into curriculum/uuid/.