### PR TITLE
Make "Vervangt" and "Vervangen door" `h3` instead of `label`

### DIFF
--- a/data-browser/index.html
+++ b/data-browser/index.html
@@ -224,7 +224,7 @@
                     </span>
                     <div data-simply-field="item.replacedBy" data-simply-content="template" data-simply-transformer="replaces">
                         <template data-simply-template="true">
-                            <label>Vervangen door</label>
+                            <h3>Vervangen door</h3>
                             <ul data-simply-list="item.replacedBy">
                                 <template rel="links"></template>
                             </ul>
@@ -232,7 +232,7 @@
                     </div>
                     <div data-simply-field="item.replaces" data-simply-content="template" data-simply-transformer="replaces">
                         <template data-simply-template="true">
-                            <label>Vervangt</label>
+                            <h3>Vervangt</h3>
                             <ul data-simply-list="item.replaces">
                                 <template rel="links"></template>
                             </ul>


### PR DESCRIPTION
Before:
![image](https://github.com/slonl/curriculum-rest-api/assets/11472320/cc0aa8f7-5c3d-4b67-ac68-b27367b2812a)

After:
![image](https://github.com/slonl/curriculum-rest-api/assets/11472320/2fd9c41c-a9d6-4caf-a9de-a947d8e2199f)
