### PR TITLE
doel should not contain a prefix in curriculum-basis.js

### DIFF
--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -244,7 +244,10 @@ module.exports = {
 		.slice(Paging.start,Paging.end)
 		.select({
 			'@context': 'https://opendata.slo.nl/curriculum/schemas/doel.jsonld#Doel',
-			...shortInfo,
+			'@id': Id,
+			uuid: _.id,
+			'@type': Type,
+			title: _
 		})
 		
 		const meta = {


### PR DESCRIPTION
according to context.json in curriculum-basis, "doel" does not have a prefix.

Replaced the
 
...shortInfo 

in curriculum-basis.js "Doel" with 	

 '@id': Id,
uuid: _.id,
'@type': Type,
title: _

thus removing the prefix: _,