### PR TITLE
curriculum-basis.js using fragment for Doelniveau

### DIFF
--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -260,23 +260,7 @@ module.exports = {
 		Doelniveau: `
 		const results = from(data.Doelniveau)
 		.slice(Paging.start, Paging.end)
-		.select({
-			'@context': 'https://opendata.slo.nl/curriculum/schemas/doel.jsonld#Doelniveau',
-			...shortInfo,
-			ce_se: _,
-			Doel: {
-				'@context': 'https://opendata.slo.nl/curriculum/schemas/doel.jsonld#Doel',
-				...shortInfo,
-				description: _,
-				vakbegrippen: _,
-				bron: _,
-				aanbodid: _,
-				Leerlingtekst: {
-					title: _,
-					description: _,
-				}     
-			},
-		})
+		.select( Doelniveau )
 
 		const meta = {
 			data: results,


### PR DESCRIPTION
Doeniveau has a fragment, put it in the Doelniveau queries, this is because - if I remember correctly- we found out Doelniveau should not contain a title: _ in its root object.