### PR TITLE
Update curriculum-syllabus.js

### DIFF
--- a/src/opendata-api/curriculum-syllabus.js
+++ b/src/opendata-api/curriculum-syllabus.js
@@ -10,7 +10,10 @@ module.exports = {
 			})
 			.slice(Paging.start,Paging.end)
 			.select({
-				...shortInfo,  
+				'@id': Id,
+				uuid: _.id,
+				'@type': Type,
+				title: _
 			})
 
 			const meta = {


### PR DESCRIPTION
Syllabus prefix is empty and not needed according to the context.json, replaced shortinfo with everything in the shortinfo except the prefix.