### PR TITLE
Update curriculum-syllabus.js

### DIFF
--- a/src/opendata-api/curriculum-syllabus.js
+++ b/src/opendata-api/curriculum-syllabus.js
@@ -52,7 +52,10 @@ module.exports = {
 			})
 			.slice(Paging.start,Paging.end)
 			.select({
-				...shortInfo,
+				'@id': Id,
+				'@type': Type,
+				uuid: _.id,
+				title: _,
 				Syllabus: {
 					...shortInfo,
 					deprecated: _,


### PR DESCRIPTION
No prefix needed in the root of syllabus_vakleergebied: replaced ...shortinfo with the appropriate fields.