### PR TITLE
Update curriculum-examenprogramma.js

### DIFF
--- a/src/opendata-api/curriculum-examenprogramma.js
+++ b/src/opendata-api/curriculum-examenprogramma.js
@@ -31,7 +31,12 @@ module.exports = {
 				title:asc
 			})
 			.slice(Paging.start,Paging.end)
-			.select(shortInfo)
+			.select({	    
+				'@id': Id,
+				uuid: _.id,
+				'@type': Type,
+				title: _,
+			})
 			
 			const meta = {
 				data: results,


### PR DESCRIPTION
prefix not needed, replaced shortinfo with {	    
				'@id': Id,
				uuid: _.id,
				'@type': Type,
				title: _,
			}
			
			
			examenprogramma_vakleergebied context.json: "required": [ "id", "title", "vakleergebied_id" ]	