### PR TITLE
fix: switch to spreadsheet

### DIFF
--- a/www/assets/js/databrowser.js
+++ b/www/assets/js/databrowser.js
@@ -1149,7 +1149,7 @@ browser = simply.app({
             browser.actions.clearView()
             let currentView = this.app.view.view;
             let item = this.app.view.item
-            let id = item?.id ?? item?.uuid
+            let id = item?.id || item?.uuid
             if (!id) {
                 return
             }


### PR DESCRIPTION
fix: the ?? in switchview didn't work when the item.id was an empty string, replaced with ||.