### PR TITLE
Bug/niveau vakleergebied

### DIFF
--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -277,17 +277,31 @@ module.exports = {
 
 		`,
 		NiveauVakleergebied:`
-		const results = from(data.Doelniveau)
-		.slice(Paging.start, Paging.end)
-		.select( Doelniveau )
-		const response = {
-			data: results,
-			page: Page,
-			count: data.Doelniveau.length,
-			root: meta.schema.types.Doelniveau.root
-		}
+		const ExamenprogrammaVakleergebied = o => from(o?.Examenprogramma).select(Niveau)
+		const SyllabusVakleergebied = o => from(o?.Syllabus).select(NiveauIndex)
+		const KerndoelVakleergebied = o => from(o?.KerndoelVakleergebied).select(NiveauIndex)
+		const LdkVakleergebied = o => from(o?.LdkVakleergebied).select(NiveauIndex)
+		const InhVakleergebied = o => from(o?.InhVakleergebied).select(NiveauIndex)
+		const results = from(data.Niveau)
+		.orderBy({ 
+				title:asc 
+			})
+		.select({
+			...shortInfo,
+			'@references': _,
+			description: _,
+			Vakleergebied: ShortLink,
+			ErkVakleergebied: ShortLink,
+			RefVakleergebied: ShortLink,
+			KerndoelVakleergebied,
+			ExamenprogrammaVakleergebied,
+			SyllabusVakleergebied,
+			LdkVakleergebied,
+			InhVakleergebied,
+			Niveau
+		})
 
-		response
+		results
 
 		`,
 	},

--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -278,27 +278,35 @@ module.exports = {
 		`,
 		NiveauVakleergebied:`
 		const ExamenprogrammaVakleergebied = o => from(o?.Examenprogramma).select(Niveau)
+		const ErkVakleergebied = o => from(o?.ErkVakleergebied).select(Niveau)
+
 		const SyllabusVakleergebied = o => from(o?.Syllabus).select(NiveauIndex)
 		const KerndoelVakleergebied = o => from(o?.KerndoelVakleergebied).select(NiveauIndex)
 		const LdkVakleergebied = o => from(o?.LdkVakleergebied).select(NiveauIndex)
 		const InhVakleergebied = o => from(o?.InhVakleergebied).select(NiveauIndex)
+		const RefVakleergebied = o => from(o?.RefVakleergebied).select(NiveauIndex)
+
 		const results = from(data.Niveau)
 		.orderBy({ 
 				title:asc 
-			})
+		})
 		.select({
-			...shortInfo,
 			'@references': _,
+			...shortInfo,
 			description: _,
 			Vakleergebied: ShortLink,
-			ErkVakleergebied: ShortLink,
+			ErkVakleergebied,
 			RefVakleergebied: ShortLink,
+			ExamenprogrammaVakleergebied: ShortLink,
+
+			Niveau,
 			KerndoelVakleergebied,
-			ExamenprogrammaVakleergebied,
 			SyllabusVakleergebied,
 			LdkVakleergebied,
 			InhVakleergebied,
-			Niveau
+			ErkVakleergebied,
+			RefVakleergebied
+			
 		})
 
 		results

--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -277,37 +277,31 @@ module.exports = {
 
 		`,
 		NiveauVakleergebied:`
-		const ExamenprogrammaVakleergebied = o => from(o?.Examenprogramma).select(Niveau)
 		const ErkVakleergebied = o => from(o?.ErkVakleergebied).select(Niveau)
-
 		const SyllabusVakleergebied = o => from(o?.Syllabus).select(NiveauIndex)
 		const KerndoelVakleergebied = o => from(o?.KerndoelVakleergebied).select(NiveauIndex)
 		const LdkVakleergebied = o => from(o?.LdkVakleergebied).select(NiveauIndex)
 		const InhVakleergebied = o => from(o?.InhVakleergebied).select(NiveauIndex)
 		const RefVakleergebied = o => from(o?.RefVakleergebied).select(NiveauIndex)
-
+		
 		const results = from(data.Niveau)
-		.orderBy({ 
-				title:asc 
-		})
-		.select({
-			'@references': _,
-			...shortInfo,
-			description: _,
-			Vakleergebied: ShortLink,
-			ErkVakleergebied,
-			RefVakleergebied: ShortLink,
-			ExamenprogrammaVakleergebied: ShortLink,
-
-			Niveau,
-			KerndoelVakleergebied,
-			SyllabusVakleergebied,
-			LdkVakleergebied,
-			InhVakleergebied,
-			ErkVakleergebied,
-			RefVakleergebied
-			
-		})
+			.orderBy({ 
+					title:asc 
+			})
+			.select({
+				...shortInfo,
+				Vakleergebied: shortInfo,
+				ErkVakleergebied: ErkVakleergebied,
+				RefVakleergebied: ShortLink,
+				ExamenprogrammaVakleergebied: o => from( _.Examenprogramma.ExamenprogrammaVakleergebied(o)).select(shortInfo),
+				Niveau,
+				KerndoelVakleergebied,
+				SyllabusVakleergebied,
+				LdkVakleergebied,
+				InhVakleergebied,
+				ErkVakleergebied,
+				RefVakleergebied
+			})
 
 		results
 

--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -289,7 +289,6 @@ module.exports = {
 				ErkVakleergebied: ShortLink,
 				RefVakleergebied: ShortLink,
 				ExamenprogrammaVakleergebied: o => from( _.Examenprogramma.ExamenprogrammaVakleergebied(o)).orderBy({title:asc}).select(ShortLink),
-				
 				Niveau: tinyNiveauIndex,
 				KerndoelVakleergebied: o => from(o?.KerndoelVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
 				SyllabusVakleergebied: o => from(o?.SyllabusVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),

--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -277,30 +277,26 @@ module.exports = {
 
 		`,
 		NiveauVakleergebied:`
-		const ErkVakleergebied = o => from(o?.ErkVakleergebied).select(Niveau)
-		const SyllabusVakleergebied = o => from(o?.Syllabus).select(NiveauIndex)
-		const KerndoelVakleergebied = o => from(o?.KerndoelVakleergebied).select(NiveauIndex)
-		const LdkVakleergebied = o => from(o?.LdkVakleergebied).select(NiveauIndex)
-		const InhVakleergebied = o => from(o?.InhVakleergebied).select(NiveauIndex)
-		const RefVakleergebied = o => from(o?.RefVakleergebied).select(NiveauIndex)
-		
+		const tinyNiveauIndex = o => from(o.NiveauIndex).orderBy({title:asc}).select(ShortLink)
+
 		const results = from(data.Niveau)
 			.orderBy({ 
-					title:asc 
+				title:asc 
 			})
 			.select({
-				...shortInfo,
-				Vakleergebied: shortInfo,
-				ErkVakleergebied: ErkVakleergebied,
+				...ShortLink,
+				Vakleergebied: ShortLink,
+				ErkVakleergebied: ShortLink,
 				RefVakleergebied: ShortLink,
-				ExamenprogrammaVakleergebied: o => from( _.Examenprogramma.ExamenprogrammaVakleergebied(o)).select(shortInfo),
-				Niveau,
-				KerndoelVakleergebied,
-				SyllabusVakleergebied,
-				LdkVakleergebied,
-				InhVakleergebied,
-				ErkVakleergebied,
-				RefVakleergebied
+				ExamenprogrammaVakleergebied: o => from( _.Examenprogramma.ExamenprogrammaVakleergebied(o)).orderBy({title:asc}).select(ShortLink),
+				
+				Niveau: tinyNiveauIndex,
+				KerndoelVakleergebied: o => from(o?.KerndoelVakleergebied).orderBy({title:asc}).select(Niveau),
+				SyllabusVakleergebied: o => from(o?.SyllabusVakleergebied).orderBy({title:asc}).select(Niveau),
+				LdkVakleergebied: o => from(o?.LdkVakleergebied).orderBy({title:asc}).select(Niveau),
+				InhVakleergebied: o => from(o?.InhVakleergebied).orderBy({title:asc}).select(Niveau),
+				VerkeerdeErkVakleergebied: o => from(o?.ErkVakleergebied).orderBy({title:asc}).select(Niveau),
+				RefVakleergebied: o => from(o?.RefVakleergebied).orderBy({title:asc}).select(Niveau),
 			})
 
 		results

--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -277,7 +277,7 @@ module.exports = {
 
 		`,
 		NiveauVakleergebied:`
-		const tinyNiveauIndex = o => from(o.NiveauIndex).orderBy({title:asc}).select(ShortLink)
+		const tinyNiveauIndex = o => from(o.NiveauIndex).select(ShortLink)
 
 		const results = from(data.Niveau)
 			.orderBy({ 
@@ -291,12 +291,12 @@ module.exports = {
 				ExamenprogrammaVakleergebied: o => from( _.Examenprogramma.ExamenprogrammaVakleergebied(o)).orderBy({title:asc}).select(ShortLink),
 				
 				Niveau: tinyNiveauIndex,
-				KerndoelVakleergebied: o => from(o?.KerndoelVakleergebied).orderBy({title:asc}).select(Niveau),
-				SyllabusVakleergebied: o => from(o?.SyllabusVakleergebied).orderBy({title:asc}).select(Niveau),
-				LdkVakleergebied: o => from(o?.LdkVakleergebied).orderBy({title:asc}).select(Niveau),
-				InhVakleergebied: o => from(o?.InhVakleergebied).orderBy({title:asc}).select(Niveau),
-				VerkeerdeErkVakleergebied: o => from(o?.ErkVakleergebied).orderBy({title:asc}).select(Niveau),
-				RefVakleergebied: o => from(o?.RefVakleergebied).orderBy({title:asc}).select(Niveau),
+				KerndoelVakleergebied: o => from(o?.KerndoelVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
+				SyllabusVakleergebied: o => from(o?.SyllabusVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
+				LdkVakleergebied: o => from(o?.LdkVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
+				InhVakleergebied: o => from(o?.InhVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
+				VerkeerdeErkVakleergebied: o => from(o?.ErkVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
+				RefVakleergebied: o => from(o?.RefVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
 			})
 
 		results

--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -276,6 +276,20 @@ module.exports = {
 		response
 
 		`,
+		NiveauVakleergebied:`
+		const results = from(data.Doelniveau)
+		.slice(Paging.start, Paging.end)
+		.select( Doelniveau )
+		const response = {
+			data: results,
+			page: Page,
+			count: data.Doelniveau.length,
+			root: meta.schema.types.Doelniveau.root
+		}
+
+		response
+
+		`,
 	},
 	typedQueries: {
 		Vakleergebied: `
@@ -337,6 +351,7 @@ module.exports = {
 	},
 	routes: {
 		'vakleergebied/': (req) => opendata.api["Vakleergebied"](req.params, req.query),
+		'niveau_vakleergebied/': (req) => opendata.api["NiveauVakleergebied"](req.params, req.query),
 		'niveau/': (req) => opendata.api["Niveau"](req.params, req.query),
 		'doel/': (req) => opendata.api["Doel"](req.params, req.query),
 		'doelniveau/': (req) => opendata.api["Doelniveau"](req.params, req.query),

--- a/src/opendata-api/curriculum-basis.js
+++ b/src/opendata-api/curriculum-basis.js
@@ -295,8 +295,7 @@ module.exports = {
 				SyllabusVakleergebied: o => from(o?.SyllabusVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
 				LdkVakleergebied: o => from(o?.LdkVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
 				InhVakleergebied: o => from(o?.InhVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
-				VerkeerdeErkVakleergebied: o => from(o?.ErkVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
-				RefVakleergebied: o => from(o?.RefVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex),
+				RefVakleergebied: o => from(o?.RefVakleergebied).orderBy({title:asc}).select(tinyNiveauIndex)
 			})
 
 		results


### PR DESCRIPTION
niveau_vakleergebied toegevoegd, wel even aan Jurre nog vragen of de "null" ipv "[]" results ok zijn. Plus een mogelijke "sanity check."

Ter referentie: ik heb de "oude" api call gebruikt als referentie en deze zo goed mogelijk omgezet naar jaqt. En met Insomnium ( open source versie postman) de data vergeleken, en het zag er redelijk "sane" uit.

Oude versie:
https://github.com/slonl/curriculum-rest-api/blob/release-2024/src/opendata-api/curriculum-basis.js
