### PR TITLE
curriculum erk data wordt opgehaald uit data.ErkGebied ipv data.ErkSc…

### DIFF
--- a/src/opendata-api/curriculum-erk.js
+++ b/src/opendata-api/curriculum-erk.js
@@ -256,7 +256,7 @@ module.exports = {
 		`,
 		// @TODO : Find ErkSchalen en context
 		ErkSchalen: `
-		const results = from(data.ErkSchalen)
+		const results = from(data.ErkGebied)
 			.orderBy({
 				prefix:asc
 			})
@@ -295,7 +295,7 @@ module.exports = {
 			const response = {
 				data: results,
 				page: Page,
-				count: data.ErkSchalen.length
+				count: data.ErkGebied.length
 			}
 	
 			response`,


### PR DESCRIPTION
curriculum erk data wordt opgehaald uit data.ErkGebied ipv data.ErkSchalen

dubbelcheck met een api call gedaan, de data zag er sane uit. De structuur volgt https://github.com/slonl/curriculum-rest-api/blob/master/src/opendata-api/curriculum-erk.js#L199 