### PR TITLE
removed .slice() voor ErkVolledig call

### DIFF
--- a/src/opendata-api/curriculum-erk.js
+++ b/src/opendata-api/curriculum-erk.js
@@ -238,14 +238,12 @@ module.exports = {
 		`,
 		// @TODO : ErkVolledig in https://github.com/slonl/curriculum-erk/blob/editor/schema.jsonld zetten?
 		ErkVolledig: `
-		const results = from(Index(request.query.id))
+		from(Index(request.query.id))
 			.select({
 				//'@context': 'http://opendata.slo.nl/curriculum/schemas/erk.jsonld#erk_vakleergebied',	
 				...shortInfo,
 				Niveau: NiveauShort
 		  	})
-
-			results
 		`,
 		// @TODO : Find ErkSchalen en context
 		ErkSchalen: `

--- a/src/opendata-api/curriculum-erk.js
+++ b/src/opendata-api/curriculum-erk.js
@@ -239,20 +239,13 @@ module.exports = {
 		// @TODO : ErkVolledig in https://github.com/slonl/curriculum-erk/blob/editor/schema.jsonld zetten?
 		ErkVolledig: `
 		const results = from(Index(request.query.id))
-			.slice(Paging.start,Paging.end)
 			.select({
 				//'@context': 'http://opendata.slo.nl/curriculum/schemas/erk.jsonld#erk_vakleergebied',	
 				...shortInfo,
 				Niveau: NiveauShort
 		  	})
 
-			const response = {
-				data: results,
-				page: Page,
-				count: Index(request.query.id).length
-			}
-
-			response
+			results
 		`,
 		// @TODO : Find ErkSchalen en context
 		ErkSchalen: `


### PR DESCRIPTION
ziet er naar uit dat de .slice niet op rom(Index(request.query.id)) wou werken, daarnaast zag ik dat de oorspronkelijke command op https://github.com/slonl/curriculum-rest-api/blob/master/src/opendata-api/curriculum-erk.js geen pagination bevatte, dus slice verwijderd.