### PR TITLE
typos fixed, one : too few and a } too many replaced Niveau with NiveauIndex

### DIFF
--- a/src/opendata-api/curriculum-syllabus.js
+++ b/src/opendata-api/curriculum-syllabus.js
@@ -140,7 +140,7 @@ module.exports = {
 			examenjaar: _,
 			status: _,
 			ce_se: _,
-			Niveau: NiveauIndex,
+			NiveauIndex : o => from( _.NiveauIndex(o)).select(Niveau),
 			SyllabusSpecifiekeEindterm: {
 				...shortInfo,
 				ce_se: _,

--- a/src/opendata-api/curriculum-syllabus.js
+++ b/src/opendata-api/curriculum-syllabus.js
@@ -145,7 +145,7 @@ module.exports = {
 				...shortInfo,
 				ce_se: _,
 				deprecated: _,
-				Tag {
+				Tag: {
 					...shortInfo,
 					deprecated: _,
 				},
@@ -196,7 +196,6 @@ module.exports = {
 					deprecated: _,
 				}
 			}
-		  }
 		})
 		`
 	},


### PR DESCRIPTION
typos fixed -> one ":" too few and a "}" too many.'syllabus/:id/' api call works now.