### PR TITLE
[n["@type"] instead of browser.view.listType 

### DIFF
--- a/www/assets/js/api.js
+++ b/www/assets/js/api.js
@@ -244,7 +244,7 @@
                 let validColumns = []
                 
                 if (browser.view.user){
-                    validColumns = Object.keys(meta.schemas.types[browser.view.listType].properties)
+                    validColumns = Object.keys(meta.schemas.types[n["@type"]].properties)
                 } else {
                     validColumns = Object.keys(n)
                     .filter(c => c[0].match(/[a-z]/))


### PR DESCRIPTION
changed getColumns to fetch the @type from the right place instead of browser.view.listType